### PR TITLE
Access to server localnet 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,7 @@ var log = new Log('info');
 
 // constants
 var DEFAULT_PORT = 11311;
+var DEFAULT_HOST = 'localhost';
 
 /**
  * Client for simplecached.
@@ -42,7 +43,7 @@ exports.Client = function(options, callback)
 		var parsedPort = parseInt(options, 10);
 		var params = {
 			port: parsedPort || options.port || DEFAULT_PORT,
-			host: 'localhost',
+			host: options.host || DEFAULT_HOST,
 		};
 		client = net.connect(params, callback);
 		client.on('data', receiveData);


### PR DESCRIPTION
Change localhost /lib/client.js to set as default but can read variable. To connect to an other server in localnetwork (teacher server, student client) lines affected 20 and 46
